### PR TITLE
Remove unnecessary trailing param to event()

### DIFF
--- a/lib/pageChange.js
+++ b/lib/pageChange.js
@@ -52,7 +52,7 @@ pageChange._logPage = function () {
 
 pageChange._logPage()
 if (window.history) {
-  event(window, 'popstate', pageChange._logPage, false);
+  event(window, 'popstate', pageChange._logPage);
   (function (h) {
     if (!h) return
     var pushState = h.pushState
@@ -62,5 +62,5 @@ if (window.history) {
     }
   })(window.history)
 } else {
-  event(window, 'hashchange', pageChange._logPage, false)
+  event(window, 'hashchange', pageChange._logPage)
 }

--- a/lib/pageLoadStats.js
+++ b/lib/pageLoadStats.js
@@ -44,6 +44,6 @@ if (typeof window.performance === 'object') {
   if (document.readyState === 'complete') {
     pageLoadStats._calculateStats()
   } else {
-    event(window, 'load', pageLoadStats._calculateStats, false)
+    event(window, 'load', pageLoadStats._calculateStats)
   }
 }

--- a/lib/xhrStats.js
+++ b/lib/xhrStats.js
@@ -59,7 +59,7 @@ window.XMLHttpRequest = function () {
 
         event(req, 'readystatechange', function () {
           readyStateTimes[xhrStates[req.readyState]] = new Date()
-        }, false)
+        })
 
         event(req, 'loadend', function (event) {
           return xhrStats._logMetrics({
@@ -70,7 +70,7 @@ window.XMLHttpRequest = function () {
             total: (new Date()) - offset,
             request: req
           })
-        }, false)
+        })
       } catch (e) {
         /* Doh */
       }


### PR DESCRIPTION
There was a bunch of `, false` arguments kicking around from a refactor, this cleans them up.