### PR TITLE
Add meta tag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Every website monitoring tool I've seen that is said to work with single page ap
     ...
 ```
 
+*IMPORTANT* - The HTML document MUST contain a `<meta>` tag indicating the page contents are encoded in UTF-8 or the packed JS payload won't work. This project uses a combination of `UglifyJS` and `JSCrush` to provide the smallest possible payload to reduce any impact it may have on page load.
+
 If you want to see the generated metrics in your console, you can set `window.barometer.debug` to any truthy value.
 
 ### Metric Payload

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Every website monitoring tool I've seen that is said to work with single page ap
 ```html
 <!DOCTYPE html>
   <head>
+    <meta charset="utf-8">
     <script type="text/javascript">--PASTE-SCRIPT-HERE--</script>
     <script type="text/javascript">window.barometer.url='https://foobar'</script>
     ...


### PR DESCRIPTION
It's important that the HTML document contains a `<meta>` tag indicating the page contents are encoded in `UTF-8` or the packed JS payload won't work correctly. This PR adds the meta tag to the README.