### PR TITLE
Improve XHR timing accuracy

### DIFF
--- a/lib/xhrStats.js
+++ b/lib/xhrStats.js
@@ -12,10 +12,8 @@ xhrStats._createGaugeName = function (stat) {
   return 'xhr.' + stat
 }
 
-xhrStats._normaliseStats = function (stats, offset, total) {
-  var normalisedStats = {
-    total: total
-  }
+xhrStats._normaliseStats = function (stats, offset) {
+  var normalisedStats = { }
 
   for (var stat in stats) {
     if (stat[0] === '_') continue
@@ -29,7 +27,7 @@ xhrStats._normaliseStats = function (stats, offset, total) {
 xhrStats._logMetrics = function (data) {
   var safeUrl = urlSanitiser(data.url)
   var metricPostfix, metric
-  var normalisedTimings = xhrStats._normaliseStats(data.readyStateTimes, data.offset, data.total)
+  var normalisedTimings = xhrStats._normaliseStats(data.readyStateTimes, data.offset)
 
   for (var stat in normalisedTimings) {
     metricPostfix = 'timing.' + data.type + '.' + safeUrl + '.' + stat
@@ -48,41 +46,32 @@ xhrStats._logMetrics = function (data) {
 
 window.XMLHttpRequest = function () {
   var req = new xhrStats._XMLHttpRequest()
-  try {
-    var readyStateTimes = {}
-    var _open = req.open
-    var _send = req.send
+  var readyStateTimes = {}
+  var _open = req.open
+  var offset, type, url
 
-    req.open = function (type, url) {
-      try {
-        var offset = new Date()
+  event(req, 'readystatechange', function () {
+    readyStateTimes[xhrStates[req.readyState]] = new Date()
+  })
 
-        event(req, 'readystatechange', function () {
-          readyStateTimes[xhrStates[req.readyState]] = new Date()
-        })
+  event(req, 'loadend', function (event) {
+    setTimeout(function () {
+      readyStateTimes.processed = new Date()
+      return xhrStats._logMetrics({
+        type: type.toLowerCase(),
+        url: url,
+        readyStateTimes: readyStateTimes,
+        offset: offset,
+        request: req
+      })
+    }, 0)
+  })
 
-        event(req, 'loadend', function (event) {
-          return xhrStats._logMetrics({
-            type: (type || 'unknown').toLowerCase(),
-            url: url,
-            readyStateTimes: readyStateTimes,
-            offset: offset,
-            total: (new Date()) - offset,
-            request: req
-          })
-        })
-      } catch (e) {
-        /* Doh */
-      }
-
-      return _open.apply(req, arguments)
-    }
-
-    req.send = function () {
-      return _send.apply(req, arguments)
-    }
-  } catch (e) {
-    /* Doh */
+  req.open = function (atype, aurl) {
+    offset = new Date()
+    type = atype
+    url = aurl
+    return _open.apply(req, arguments)
   }
   return req
 }

--- a/test/testXhrStats.js
+++ b/test/testXhrStats.js
@@ -13,6 +13,7 @@ describe('Testing xhrStats', function () {
     var xhr = new window.XMLHttpRequest()
     xhr.open('POST', 'www.example.com/foo', true)
     xhr.send('datadatadatadata')
+    window.clock.tick(1)
   })
   after(function () {
     transport.gauge.restore()
@@ -21,7 +22,7 @@ describe('Testing xhrStats', function () {
   })
 
   it('should measure XHR timings', function () {
-    sinon.assert.calledWith(transport.gauge, 'xhr.timing.post.www_example_com.foo.total', 0)
+    sinon.assert.calledWith(transport.gauge, 'xhr.timing.post.www_example_com.foo.processed', 0)
     sinon.assert.calledWith(transport.gauge, 'xhr.timing.post.www_example_com.foo.unsent', 0)
     sinon.assert.calledWith(transport.gauge, 'xhr.timing.post.www_example_com.foo.opened', 0)
     sinon.assert.calledWith(transport.gauge, 'xhr.timing.post.www_example_com.foo.headers_received', 0)


### PR DESCRIPTION
This improves the way in which we measure XHR timing, following a deep dive in to how 3rd party libraries utilise XMLHttpRequest. The listeners we attach to the XMLHttpRequest object are now attached immediately after creating the object, instead of deferring them until after `.open()` has been called. This ensure correct timings using the `superagent` by beating userland code to the race and ensuring we get the very first event. There was value in the original measurement, so we now defer processing of the second measurement to the back of the event loop to allow all userland code to execute before our measure gets taken.