### PR TITLE
Easier page timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ If you want to see the generated metrics in your console, you can set `window.ba
 
 ### Taking Readings
 
-* `barometer.gauge(metric, duration)` is a measure of "this event took this long". `metric` is the full metric path, so chose wisely!
-* `barometer.count(metric)` is a measure of "this event just happened". `metric` is the full metric path, so chose wisely!
+* `barometer.gauge(metric, duration)` is a measure of "this event took this long". `metric` is the full metric path, so choose wisely!
+* `barometer.count(metric)` is a measure of "this event just happened". `metric` is the full metric path, so choose wisely!
 * `barometer.offset(metric)` is a measure of "this event just happened now, relative to pageLoad". The metric path will be prefixed with `pageLoad.[domain].[path].` to keep the measurements inline with those gathered out-of-the-box. This feature is great for digging deeper into the bootstrapping process of a single page application.
 
 ### Metric Payload

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Every website monitoring tool I've seen that is said to work with single page ap
 
 If you want to see the generated metrics in your console, you can set `window.barometer.debug` to any truthy value.
 
+### Taking Readings
+
+* `barometer.gauge(metric, duration)` is a measure of "this event took this long". `metric` is the full metric path, so chose wisely!
+* `barometer.count(metric)` is a measure of "this event just happened". `metric` is the full metric path, so chose wisely!
+* `barometer.offset(metric)` is a measure of "this event just happened now, relative to pageLoad". The metric path will be prefixed with `pageLoad.[domain].[path].` to keep the measurements inline with those gathered out-of-the-box. This feature is great for digging deeper into the bootstrapping process of a single page application.
+
 ### Metric Payload
 
 Metrics are gathered in the format used by a statsd / graphite / grafana stack - there are two types, gauges and counters. The buffered metric payloads sent to the collection service of your choosing look like this:
@@ -83,8 +89,9 @@ This module exposes a mechanism for other pieces of Javascript to generate metri
 window.barometer = {
   url: null,
   debug: null,
-  count: function (metric),
+  count: function (metric) { },
   gauge: function (metric, value) { },
+  offset: function(metric) { },
   onPageChanged: function(callback) { },
   oncePageLoaded: function(callback) { }
 }

--- a/lib/barometer.js
+++ b/lib/barometer.js
@@ -3,12 +3,14 @@
 var tracker = window.barometer = module.exports = {}
 
 var transport = require('./transport.js')
-var pageChange = require('./pageChange')
+var pageChange = require('./pageChange.js')
+var measures = require('./measures.js')
 require('./pageLoadStats.js')
 require('./xhrStats.js')
 require('./pageResources')
 
 tracker.url = null
+tracker.offset = measures.offset
 tracker.gauge = transport.gauge
 tracker.count = transport.count
 tracker.onPageChanged = pageChange.onPageChanged

--- a/lib/measures.js
+++ b/lib/measures.js
@@ -1,0 +1,14 @@
+/* global window */
+'use strict'
+var measures = module.exports = {}
+
+var barometer = require('./barometer.js')
+var urlSanitiser = require('./urlSanitiser.js')
+var transport = require('./transport.js')
+
+measures.offset = function (stat) {
+  var timeDiff = (new Date()) - barometer.pageStartedAt
+  var safeUrl = urlSanitiser(window.location.href, window.location.hash)
+  var metric = 'pageload.' + safeUrl + '.' + stat.replace(/[^a-z0-9-]/gi, '_')
+  transport.gauge(metric, timeDiff)
+}

--- a/lib/pageChange.js
+++ b/lib/pageChange.js
@@ -5,6 +5,7 @@ var pageChange = module.exports = {}
 var event = require('./event.js')
 var pageLoadStats = require('./pageLoadStats.js')
 var transport = require('./transport.js')
+var barometer = require('./barometer.js')
 
 var pageCounter = 0
 var onPageChanged = [ ]
@@ -13,12 +14,13 @@ pageChange._pageEnd = function () {
   transport.gauge(pageLoadedId, (new Date()) - pageLoadedAt)
 }
 pageChange._logPage = function () {
+  var navStart = new Date()
+  barometer.pageStartedAt = navStart
   transport.count(pageLoadStats._createGaugeName('visits'))
   if (pageLoadedAt) {
     pageChange._pageEnd()
   }
   pageCounter++
-  var navStart = new Date()
   var thisPage = pageCounter
   var maxLag = 0
   var lastLag = [ 9, 9, 9, 9, 9 ]

--- a/lib/pageLoadStats.js
+++ b/lib/pageLoadStats.js
@@ -3,6 +3,7 @@
 var pageLoadStats = module.exports = {}
 
 var event = require('./event.js')
+var barometer = require('./barometer.js')
 var transport = require('./transport.js')
 var urlSanitiser = require('./urlSanitiser.js')
 
@@ -19,6 +20,9 @@ pageLoadStats._normaliseStats = function (stats) {
     normalisedStats[stat] = stats[stat] - offset
   }
 
+  if (stats.navigationStart !== 0) {
+    normalisedStats.timeToFirstScript = barometer.pageStartedAt - stats.navigationStart
+  }
   return normalisedStats
 }
 

--- a/test/testMeasures.js
+++ b/test/testMeasures.js
@@ -1,0 +1,25 @@
+/* global window */
+'use strict'
+var sinon = require('sinon')
+require('./_fakeDom.js')
+var measures = require('../lib/measures.js')
+var transport = require('../lib/transport.js')
+
+describe('Testing measures', function () {
+  before(function (done) {
+    sinon.stub(transport, 'gauge')
+    window.clock = sinon.useFakeTimers()
+    window.barometer.pageStartedAt = new Date()
+    window.clock.setSystemTime((new Date()).getTime() + 100)
+    done()
+  })
+  after(function () {
+    transport.gauge.restore()
+    window.clock.restore()
+  })
+
+  it('should measure times offset from page change start', function () {
+    measures.offset('xxxxx')
+    sinon.assert.calledWith(transport.gauge, 'pageload.localhost_9876.context_html.xxxxx', 100)
+  })
+})

--- a/test/testPageLoadStats.js
+++ b/test/testPageLoadStats.js
@@ -9,6 +9,7 @@ var transport = require('../lib/transport.js')
 describe('Testing pageLoadStats', function () {
   before(function () {
     sinon.stub(transport, 'gauge')
+    window.barometer.pageStartedAt = 6
     window.trigger('load')
   })
   after(function () {
@@ -36,7 +37,8 @@ describe('Testing pageLoadStats', function () {
     sinon.assert.calledWith(transport.gauge, 'pageload.localhost_9876.context_html.domComplete', 18)
     sinon.assert.calledWith(transport.gauge, 'pageload.localhost_9876.context_html.loadEventStart', 19)
     sinon.assert.calledWith(transport.gauge, 'pageload.localhost_9876.context_html.loadEventEnd', 20)
+    sinon.assert.calledWith(transport.gauge, 'pageload.localhost_9876.context_html.timeToFirstScript', 5)
     sinon.assert.calledWith(transport.gauge, 'pageload.localhost_9876.context_html.redirects', 2)
-    assert.equal(transport.gauge.callCount, 21)
+    assert.equal(transport.gauge.callCount, 22)
   })
 })


### PR DESCRIPTION
This enables a new feature:
```
window.barometer.offset('somethingJustLoaded')
```
Which will build up a `pageLoad` metric, with the sanitised page url, postfix it with `somethingJustLoaded` and take a measure between when the barometer script first loaded (when the first script, inlined in the head of the page, began) and the current timestamp.

There's also another metric in here - `timeToFirstScript`. This is a measure between `navigationStart` and the time when the barometer script first executes. This makes drawing graphs easier as we can stack `timeToFirstScript` and the previously mentioned pageLoad metrics to get an accurate timeline of page load events. Measuring these events separately means we can still get good readings for half of the picture even when users browsers don't support the performance API.

These changes should make tracking and graphing page load times much simpler.