### PR TITLE
A simpler approach to resource timings

### DIFF
--- a/lib/pageResources.js
+++ b/lib/pageResources.js
@@ -50,6 +50,7 @@ pageResources.initialise = function () {
 
   pageChange.onPageChanged(function () {
     var entries = window.performance.getEntries()
+    if (!entries || !entries.length) return
     for (; lastIndex < entries.length; lastIndex++) {
       pageResources.handleResource(entries[lastIndex])
     }

--- a/lib/pageResources.js
+++ b/lib/pageResources.js
@@ -5,8 +5,6 @@ var pageResources = module.exports = {}
 var pageChange = require('./pageChange.js')
 var transport = require('./transport.js')
 var lastIndex = 0
-var timingOffset = 0
-var pageStart
 
 pageResources.handleResource = function (entry) {
   var metrics = pageResources.findRule(entry)
@@ -43,7 +41,6 @@ pageResources.track = function (entry, metrics) {
     i = metrics[i]
     var value = entry[i]
     if (value === 0) continue
-    if (i !== 'duration') value = timingOffset - value
     transport.gauge(prefix + '.' + i, value)
   }
 }
@@ -51,9 +48,7 @@ pageResources.track = function (entry, metrics) {
 pageResources.initialise = function () {
   if (!window.performance || !window.performance.getEntries) return
 
-  pageStart = new Date()
   pageChange.onPageChanged(function () {
-    timingOffset = (new Date() - pageStart)
     var entries = window.performance.getEntries()
     for (; lastIndex < entries.length; lastIndex++) {
       pageResources.handleResource(entries[lastIndex])

--- a/test/testPageResources.js
+++ b/test/testPageResources.js
@@ -62,12 +62,12 @@ describe('Testing pageResources', function () {
   })
 
   it('should measure resource timings', function () {
-    sinon.assert.calledWith(transport.gauge, 'resources.type1.foo_com.bar_js.stat1', -123)
-    sinon.assert.calledWith(transport.gauge, 'resources.type2.bar_com.foo_js.stat2', -223)
+    sinon.assert.calledWith(transport.gauge, 'resources.type1.foo_com.bar_js.stat1', 123)
+    sinon.assert.calledWith(transport.gauge, 'resources.type2.bar_com.foo_js.stat2', 223)
     assert.equal(transport.gauge.callCount, 2)
     window.clock.tick(600)
-    sinon.assert.calledWith(transport.gauge, 'resources.type1.foo_com.bar_js.stat1', -223)
-    sinon.assert.calledWith(transport.gauge, 'resources.type2.bar_com.foo_js.stat2', -323)
+    sinon.assert.calledWith(transport.gauge, 'resources.type1.foo_com.bar_js.stat1', 723)
+    sinon.assert.calledWith(transport.gauge, 'resources.type2.bar_com.foo_js.stat2', 823)
     assert.equal(transport.gauge.callCount, 4)
   })
 })


### PR DESCRIPTION
Originally I intended on measuring resource timings relative to the last page load. Imagine if someone is deep within a single page app and they're navigating between "pages", if they land on a page that pulls in a resource we want to track, those timings will be relative to the users first arrival in the application. Originally I attempted to compensate for this by offsetting the timings against the time of the most recent "page load". This kind of worked, but in practise it makes graphing things way harder than I first thought. 

This PR undoes some of the cleverness and falls back on simply logging the raw numbers.