### PR TITLE
Enable resource aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ At it's heart, simply attach an array to `window.barometer.resources`. Each obje
 window.barometer.resources = [
   {
     domain: 'example.com',
-    path: /\.js$/,
-    type: /.*/,
-    metrics: [ 'startTime', 'duration' ]
+    path: /.*-assets(\.gz)\.js$/,
+    metrics: [ 'startTime', 'duration' ],
+    rename: 'assets.js'
   }
 ]
 ```

--- a/lib/pageResources.js
+++ b/lib/pageResources.js
@@ -7,9 +7,9 @@ var transport = require('./transport.js')
 var lastIndex = 0
 
 pageResources.handleResource = function (entry) {
-  var metrics = pageResources.findRule(entry)
-  if (!metrics) return
-  pageResources.track(entry, metrics)
+  var rule = pageResources.findRule(entry)
+  if (!rule) return
+  pageResources.track(entry, rule)
 }
 
 pageResources.findRule = function (entry) {
@@ -24,21 +24,20 @@ pageResources.findRule = function (entry) {
     var rule = config[i]
     if (rule.domain && !domain.match(rule.domain)) continue
     if (rule.path && !path.match(rule.path)) continue
-    if (rule.type && entry.entryType !== rule.type) continue
-    return rule.metrics
+    return rule
   }
   return null
 }
 
-pageResources.track = function (entry, metrics) {
+pageResources.track = function (entry, rule) {
   var parts = entry.name.replace(/https?:\/\//i, '').split('/')
-  var prefix = 'resources.' + entry.entryType + '.'
+  var prefix = 'resources.'
   prefix += parts.shift().replace(/[^a-z0-9_]/gi, '_')
   prefix += '.'
-  prefix += parts.join('/').split('?')[0].replace(/[^a-z0-9_]/gi, '_')
+  prefix += (rule.rename || parts.join('/')).split('?')[0].replace(/[^a-z0-9_]/gi, '_')
 
-  for (var i in metrics) {
-    i = metrics[i]
+  for (var i in rule.metrics) {
+    i = rule.metrics[i]
     var value = entry[i]
     if (value === 0) continue
     transport.gauge(prefix + '.' + i, value)

--- a/test/_fakeDom.js
+++ b/test/_fakeDom.js
@@ -17,6 +17,7 @@ if (!window.history) window.history = { }
 
 if (!window.location) {
   window.location = {
+    host: 'localhost_9876',
     href: 'localhost_9876',
     hash: '/context_html?foo=bar'
   }

--- a/test/testPageResources.js
+++ b/test/testPageResources.js
@@ -20,29 +20,28 @@ describe('Testing pageResources', function () {
     var entries = [
       {
         name: 'http://foo.com/bar.js?blarg',
-        entryType: 'type1',
         stat1: 123
       },
       {
         name: 'http://bar.com/foo.js',
-        entryType: 'type2',
         stat2: 223
       },
       {
         name: 'http://example.com/bar.js',
-        entryType: 'type3',
         stat2: 100
+      },
+      {
+        name: 'http://example.com/1234567890.payload.gz.js',
+        stat1: 100
       }
     ]
     var subsequentEntries = [
       {
         name: 'http://foo.com/bar.js',
-        entryType: 'type1',
         stat1: 723
       },
       {
         name: 'http://bar.com/foo.js',
-        entryType: 'type2',
         stat2: 823
       }
     ]
@@ -50,7 +49,8 @@ describe('Testing pageResources', function () {
     getEntries.onSecondCall().returns(entries.concat(subsequentEntries))
     window.barometer.resources = [
       { domain: 'foo.com', metrics: [ 'stat1' ] },
-      { path: /foo\.js$/, metrics: [ 'stat2' ] }
+      { path: /foo\.js$/, metrics: [ 'stat2' ] },
+      { path: /payload(\.gz)?\.js$/, metrics: [ 'stat1' ], rename: 'payload' }
     ]
     pageResources.initialise()
   })
@@ -62,12 +62,13 @@ describe('Testing pageResources', function () {
   })
 
   it('should measure resource timings', function () {
-    sinon.assert.calledWith(transport.gauge, 'resources.type1.foo_com.bar_js.stat1', 123)
-    sinon.assert.calledWith(transport.gauge, 'resources.type2.bar_com.foo_js.stat2', 223)
-    assert.equal(transport.gauge.callCount, 2)
+    sinon.assert.calledWith(transport.gauge, 'resources.foo_com.bar_js.stat1', 123)
+    sinon.assert.calledWith(transport.gauge, 'resources.bar_com.foo_js.stat2', 223)
+    sinon.assert.calledWith(transport.gauge, 'resources.example_com.payload.stat1', 100)
+    assert.equal(transport.gauge.callCount, 3)
     window.clock.tick(600)
-    sinon.assert.calledWith(transport.gauge, 'resources.type1.foo_com.bar_js.stat1', 723)
-    sinon.assert.calledWith(transport.gauge, 'resources.type2.bar_com.foo_js.stat2', 823)
-    assert.equal(transport.gauge.callCount, 4)
+    sinon.assert.calledWith(transport.gauge, 'resources.foo_com.bar_js.stat1', 723)
+    sinon.assert.calledWith(transport.gauge, 'resources.bar_com.foo_js.stat2', 823)
+    assert.equal(transport.gauge.callCount, 5)
   })
 })

--- a/test/testPageResources.js
+++ b/test/testPageResources.js
@@ -1,7 +1,6 @@
 /* global window */
 'use strict'
 var sinon = require('sinon')
-var assert = require('assert')
 require('./_fakeDom.js')
 var pageChange = require('../lib/pageChange.js')
 var transport = require('../lib/transport.js')
@@ -65,10 +64,8 @@ describe('Testing pageResources', function () {
     sinon.assert.calledWith(transport.gauge, 'resources.foo_com.bar_js.stat1', 123)
     sinon.assert.calledWith(transport.gauge, 'resources.bar_com.foo_js.stat2', 223)
     sinon.assert.calledWith(transport.gauge, 'resources.example_com.payload.stat1', 100)
-    assert.equal(transport.gauge.callCount, 3)
     window.clock.tick(600)
     sinon.assert.calledWith(transport.gauge, 'resources.foo_com.bar_js.stat1', 723)
     sinon.assert.calledWith(transport.gauge, 'resources.bar_com.foo_js.stat2', 823)
-    assert.equal(transport.gauge.callCount, 5)
   })
 })


### PR DESCRIPTION
It's common in production to name assets according to the git hash they were built from, eg `7354c2743eea199ff83b9236e3c3460bb86cae3b-assets.gz.js`. When collecting resource metrics for resources with dynamic filenames, we need to ability to rename the metrics to enable us to gather a single stat.

This PR enables us to add a new property to the resource timing config to override the resource name:
```
{ 
  path: /.*-payload(\.gz)?\.js$/,
  metrics: [ 'startTime', 'duration' ],
  rename: 'payload.js' 
}
```